### PR TITLE
fix(.github): use PAT for token

### DIFF
--- a/.github/workflows/bump-spin.yml
+++ b/.github/workflows/bump-spin.yml
@@ -36,3 +36,4 @@ jobs:
           committer: spinframeworkbot <202838904+spinframeworkbot@users.noreply.github.com>
           author: spinframeworkbot <202838904+spinframeworkbot@users.noreply.github.com>
           signoff: true
+          token: ${{ secrets.PAT }}


### PR DESCRIPTION
The default GITHUB_TOKEN doesn't have workflow edit permissions, so using a spinframework GH PAT with them.

Intended to fix errors such as this one: https://github.com/spinframework/homebrew-tap/actions/runs/14066641222/job/39393891979

```
Pushing pull request branch to 'origin/bump-spin-v3.2.0'
  /usr/bin/git push --force-with-lease origin bump-spin-v3.2.0:refs/heads/bump-spin-v3.2.0
  warning: not sending a push certificate since the receiving end does not support --signed push
  To https://github.com/spinframework/homebrew-tap
   ! [remote rejected] bump-spin-v3.2.0 -> bump-spin-v3.2.0 (refusing to allow a GitHub App to create or update workflow `.github/workflows/bump-spin.yml` without `workflows` permission)
  error: failed to push some refs to 'https://github.com/spinframework/homebrew-tap'
  Error: The process '/usr/bin/git' failed with exit code 1
```

(No, I'm not sure either why workflow edit permissions are needed in the first place 🤔 )