### PR TITLE
Revert "Migrate contents of Spin data directory to spinframework location"

### DIFF
--- a/Formula/spin.rb
+++ b/Formula/spin.rb
@@ -28,18 +28,6 @@ class Spin < Formula
   end
 
   def post_install
-    # Migrate plugins and templates and templates data to new data directory
-    source_dir = "#{HOMEBREW_PREFIX}/etc/fermyon-spin"
-    dest_dir = "#{HOMEBREW_PREFIX}/etc/spinframework-spin"
-    if File.directory?(source_dir)
-      ohai "Migrating Spin data from #{source_dir} to #{dest_dir}"
-      mkdir_p dest_dir
-      Dir.glob("#{source_dir}/*").each do |file|
-        mv(file, dest_dir)
-      end
-      Dir.rmdir(source_dir) if Dir.empty?(source_dir) # Remove if empty
-    end
-
     # Install default templates and plugins for language tooling and deploying apps to the cloud.
     # Templates and plugins are installed into `pkgetc/"templates"` and `pkgetc/"plugins"`.
     system "#{bin}/spin", "templates", "install", "--git", "https://github.com/fermyon/spin", "--upgrade"


### PR DESCRIPTION
Reverts spinframework/homebrew-tap#7

I just upgraded my plugin and it didn't move over my previously installed plugins. Right now we get a post install failed warning:
```sh
Warning: The post-install step did not complete successfully
You can try again using:
  brew postinstall spinframework/tap/spin
==> Summary
🍺  /opt/homebrew/Cellar/spin/3.2.0: 6 files, 91.9MB, built in 2 seconds
==> Running `brew cleanup spin`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

