### PR TITLE
chore(spin.rb): rm js2wasm plugin install

### DIFF
--- a/Formula/spin.rb
+++ b/Formula/spin.rb
@@ -51,7 +51,6 @@ class Spin < Formula
     system "#{bin}/spin", "templates", "install", "--git", "https://github.com/fermyon/spin-python-sdk", "--upgrade"
     system "#{bin}/spin", "templates", "install", "--git", "https://github.com/fermyon/spin-js-sdk", "--upgrade"
     system "#{bin}/spin", "plugins", "update"
-    system "#{bin}/spin", "plugins", "install", "js2wasm", "--yes"
   end
 
   test do


### PR DESCRIPTION
The `js2wasm` plugin hasn't been used in more recent versions of the spin-js-sdk if I recall correctly cc @karthik2804

Though unsure if this installation is still needed/wanted for other reasons.